### PR TITLE
Fix MAS entries syntax

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -67,10 +67,10 @@ cask 'font-cascadia-mono'
 cask 'font-cascadia-mono-pl'
 
 # Mac App Store
-mas: 'Amphetamine', id: 937984704
-mas: 'TestFlight', id: 899247664
-mas: 'Microsoft Word'. id: 462054704
-mas: 'Microsoft Excel'. id: 462058435
-mas: 'WhatsApp Messenger'. id: 310633997
-mas: 'GoodLinks'. id: 1474335294
-mas: 'Trello'. id: 1278508951
+mas 'Amphetamine', id: 937984704
+mas 'TestFlight', id: 899247664
+mas 'Microsoft Word', id: 462054704
+mas 'Microsoft Excel', id: 462058435
+mas 'WhatsApp Messenger', id: 310633997
+mas 'GoodLinks', id: 1474335294
+mas 'Trello', id: 1278508951


### PR DESCRIPTION
## Summary
- clean up MAS entries in Brewfile to follow standard Homebrew Bundle syntax

## Testing
- `brew --version 2>/dev/null` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883aca1ce5c832eaa41b730265e5ac1