### PR TITLE
Fix ssh keygen script

### DIFF
--- a/ssh.sh
+++ b/ssh.sh
@@ -4,16 +4,26 @@ echo "Generating a new SSH key for GitHub..."
 
 # Generating a new SSH key
 # https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key
-ssh-keygen -t ed25519 -C $1 -f ~/.ssh/id_ed25519
+ssh-keygen -t ed25519 -C "$1" -f ~/.ssh/id_ed25519
 
 # Adding your SSH key to the ssh-agent
 # https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent
 eval "$(ssh-agent -s)"
 
+mkdir -p ~/.ssh
 touch ~/.ssh/config
-echo "Host *\n AddKeysToAgent yes\n UseKeychain yes\n IdentityFile ~/.ssh/id_ed25519" | tee ~/.ssh/config
+cat >> ~/.ssh/config <<'EOF'
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+EOF
 
-ssh-add -K ~/.ssh/id_ed25519
+if ssh-add --help 2>&1 | grep -q -- '--apple-use-keychain'; then
+  ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+else
+  ssh-add -K ~/.ssh/id_ed25519 2>/dev/null || ssh-add ~/.ssh/id_ed25519
+fi
 
 # Adding your SSH key to your GitHub account
 # https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account


### PR DESCRIPTION
## Summary
- add quoting to ssh-keygen args
- append to existing `~/.ssh/config`
- load key using `--apple-use-keychain` when possible

## Testing
- `shellcheck ssh.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883acb17024832e90e462e2e3ad27e3