### PR TITLE
Fix param passwords

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -42,7 +42,8 @@ alias dtest="dotnet test"
 alias dwatch="dotnet watch run"
 
 # SQL Server
-alias mssql="docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=LaravelWow1986! -p 1433:1433 mcr.microsoft.com/mssql/server:2017-latest"
+# Set MSSQL_SA_PASSWORD in your environment to provide the SA password
+alias mssql="docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=${MSSQL_SA_PASSWORD} -p 1433:1433 mcr.microsoft.com/mssql/server:2017-latest"
 
 # Git
 alias gst="git status"

--- a/fresh.sh
+++ b/fresh.sh
@@ -27,7 +27,11 @@ brew tap homebrew/bundle
 brew bundle --file ./Brewfile
 
 # Set default MySQL root password and auth type
-mysql -u root -e "ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
+if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+  printf "Enter MySQL root password: "
+  read -r MYSQL_ROOT_PASSWORD
+fi
+mysql -u root -e "ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}'; FLUSH PRIVILEGES;"
 
 # Create a projects directories
 mkdir $HOME/Developer

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,11 @@ brew tap homebrew/bundle
 brew bundle
 
 # Set default MySQL root password and auth type.
-mysql -u root -e "ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
+if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+  printf "Enter MySQL root password: "
+  read -r MYSQL_ROOT_PASSWORD
+fi
+mysql -u root -e "ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}'; FLUSH PRIVILEGES;"
 
 # Install PHP extensions with PECL
 pecl install imagick memcached redis swoole


### PR DESCRIPTION
## Summary
- use `MSSQL_SA_PASSWORD` env var for the `mssql` alias
- prompt for `MYSQL_ROOT_PASSWORD` in install and fresh scripts

## Testing
- `apt-get update && apt-get install -y shellcheck`
- `shellcheck install.sh fresh.sh aliases.zsh`

------
https://chatgpt.com/codex/tasks/task_e_6883acabb764832e8c03958f6df3eb18