### PR TITLE
Remove clone.sh script

### DIFF
--- a/fresh.sh
+++ b/fresh.sh
@@ -38,9 +38,6 @@ mkdir $HOME/Developer/Kods
 mkdir $HOME/Developer/Labs
 mkdir $HOME/Developer/Learn
 
-# Clone Github repositories
-./clone.sh
-
 # Symlink the Mackup config file to the home directory
 ln -s ./.mackup.cfg $HOME/.mackup.cfg
 


### PR DESCRIPTION
## Summary
- remove `clone.sh` from the repository
- drop invocation from `fresh.sh`

## Testing
- `sh -n fresh.sh`
- `sh -n install.sh`
- `sh -n bin/setup`
- `sh -n ssh.sh`
- `shellcheck fresh.sh install.sh bin/setup ssh.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ac9bbdd8832eb516239233404ea0