### PR TITLE
Improve macOS setup script

### DIFF
--- a/.macos
+++ b/.macos
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+set -e
+
+# Customize these values for your machine
+COMPUTER_NAME="MacBook-Cesar"
+TIMEZONE="America/El_Salvador"
 
 # Close any open System Preferences panes, to prevent them from overriding
 # settings we’re about to change
@@ -15,10 +20,10 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 ###############################################################################
 
 # Set computer name (as done via System Preferences → Sharing)
-sudo scutil --set ComputerName "MacBook César"
-sudo scutil --set HostName "MacBook César"
-sudo scutil --set LocalHostName "MacBook César"
-sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server NetBIOSName -string "MacBook César"
+sudo scutil --set ComputerName "$COMPUTER_NAME"
+sudo scutil --set HostName "$COMPUTER_NAME"
+sudo scutil --set LocalHostName "$COMPUTER_NAME"
+sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server NetBIOSName -string "$COMPUTER_NAME"
 
 # Disable the sound effects on boot
 sudo nvram SystemAudioVolume=" "
@@ -154,7 +159,7 @@ defaults write NSGlobalDomain AppleMetricUnits -bool true
 # sudo defaults write /Library/Preferences/com.apple.loginwindow showInputMenu -bool true
 
 # Set the timezone; see `sudo systemsetup -listtimezones` for other values
-sudo systemsetup -settimezone "America/El_Salvador" > /dev/null
+sudo systemsetup -settimezone "$TIMEZONE" > /dev/null
 
 # Stop iTunes from responding to the keyboard media keys
 #launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ After you've set up your new Mac you may want to wipe and clean install your old
 If you want to start with your own dotfiles from this setup, it's pretty easy to do so. First of all you'll need to fork this repo. After that you can tweak it the way you want.
 
 Go through the [`.macos`](./.macos) file and adjust the settings to your liking. You can find much more settings at [the original script by Mathias Bynens](https://github.com/mathiasbynens/dotfiles/blob/master/.macos) and [Kevin Suttle's macOS Defaults project](https://github.com/kevinSuttle/MacOS-Defaults).
+At the top of that file you can define your `COMPUTER_NAME` and `TIMEZONE` variables so the script configures these values automatically.
 
 Check out the [`Brewfile`](./Brewfile) file and adjust the apps you want to install for your machine. Use [their search page](https://formulae.brew.sh/cask/) to check if the app you want to install is available.
 


### PR DESCRIPTION
## Summary
- fail early in `.macos` using `set -e`
- make computer name and timezone configurable via variables
- document the variables in README

## Testing
- `shellcheck .macos`

------
https://chatgpt.com/codex/tasks/task_e_6883bde4c644832e88808443b979a8c7