### PR TITLE
Add shell script linting workflow

### DIFF
--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git ls-files '*.sh')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: ShellCheck
         if: steps.shell.outputs.files != ''
         run: |
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git ls-files '*.zsh')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "files=$files" >> $GITHUB_OUTPUT
       - name: Zsh syntax check
         if: steps.zsh.outputs.files != ''
         run: |

--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -1,0 +1,51 @@
+name: Lint Scripts
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install lint tools
+        run: |
+          set -euo pipefail
+          echo '::group::apt-get'
+          sudo apt-get update -y
+          sudo apt-get install -y shellcheck shfmt zsh
+          echo '::endgroup::'
+      - name: List shell files
+        id: shell
+        run: |
+          set -euo pipefail
+          files=$(git ls-files '*.sh')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: ShellCheck
+        if: steps.shell.outputs.files != ''
+        run: |
+          set -euo pipefail
+          echo '::group::shellcheck'
+          shellcheck ${{ steps.shell.outputs.files }}
+          echo '::endgroup::'
+      - name: shfmt
+        if: steps.shell.outputs.files != ''
+        run: |
+          set -euo pipefail
+          echo '::group::shfmt'
+          shfmt -d -i 2 -ci -sr ${{ steps.shell.outputs.files }}
+          echo '::endgroup::'
+      - name: List zsh files
+        id: zsh
+        run: |
+          set -euo pipefail
+          files=$(git ls-files '*.zsh')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: Zsh syntax check
+        if: steps.zsh.outputs.files != ''
+        run: |
+          set -euo pipefail
+          echo '::group::zsh -n'
+          zsh -n ${{ steps.zsh.outputs.files }}
+          echo '::endgroup::'

--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -21,7 +21,9 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git ls-files '*.sh')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: ShellCheck
         if: steps.shell.outputs.files != ''
         run: |
@@ -41,7 +43,9 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git ls-files '*.zsh')
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Zsh syntax check
         if: steps.zsh.outputs.files != ''
         run: |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Lint Scripts](https://github.com/cesaramirez/dotfiles/actions/workflows/lint-scripts.yml/badge.svg)](https://github.com/cesaramirez/dotfiles/actions/workflows/lint-scripts.yml)
+
 ## A Fresh macOS Setup
 
 These instructions are for setting up a new Mac using **your own** dotfiles in this repository. If you want to customize further, see “Your Own Dotfiles” below.
@@ -117,6 +119,16 @@ See Mackup docs if you prefer a different storage (e.g., non‑iCloud).
 You can tweak the shell theme, the Oh My Zsh settings and much more. Go through the files in this repo and tweak everything to your liking.
 
 Enjoy your own Dotfiles!
+
+## Continuous Integration
+Shell (`*.sh`) files are linted with **ShellCheck** and **shfmt**, while Zsh (`*.zsh`) files are syntax checked using `zsh -n`. Run the same checks locally with:
+
+```bash
+sudo apt-get install shellcheck shfmt zsh
+git ls-files '*.sh' | xargs --no-run-if-empty shellcheck
+git ls-files '*.sh' | xargs --no-run-if-empty shfmt -d -i 2 -ci -sr
+git ls-files '*.zsh' | xargs --no-run-if-empty zsh -n
+```
 
 ## Thanks To...
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint `.sh` and check `.zsh`
- show workflow status badge in README
- document how to run the same checks locally

## Testing
- `shellcheck fresh.sh install.sh ssh.sh` *(fails: warnings present)*
- `git ls-files '*.sh' | xargs -r shfmt -d -i 2 -ci -sr` *(fails: prints diff)*
- `zsh -n aliases.zsh path.zsh`


------
https://chatgpt.com/codex/tasks/task_e_688479e0e214832ea5be6e66901e38ca