### PR TITLE
Remove unused dry-run hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After backing up your old Mac you may now follow these install instructions to s
     ```
 
 5. Start `Herd.app` and run its install process
-6. Review the `.macos` script and run it (consider `--dry-run` first) to apply system defaults
+6. Review the `.macos` script and run it to apply system defaults
 7. (Optional) If you use **Mackup** and it’s already synced with your cloud storage, restore preferences:
 
         mackup restore


### PR DESCRIPTION
## Summary
- fix README to remove suggestion to run `.macos --dry-run`

## Testing
- `shellcheck fresh.sh install.sh ssh.sh`
- `shfmt -d -i 2 -ci -sr fresh.sh install.sh ssh.sh`
- `zsh -n aliases.zsh path.zsh`


------
https://chatgpt.com/codex/tasks/task_e_6884e53610e0832ead5919b157a110bd