### PR TITLE
Implement repo enhancements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "dotfiles",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/homebrew:1": {},
+    "ghcr.io/devcontainers/features/mise:1": {}
+  },
+  "postCreateCommand": "brew bundle --file Brewfile && mise install"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{sh,zsh}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/brew-check.yml
+++ b/.github/workflows/brew-check.yml
@@ -1,0 +1,9 @@
+name: Brewfile Check
+on: [push, pull_request]
+jobs:
+  brew:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Brew bundle check
+        run: brew bundle --file Brewfile --no-lock --dry-run

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,10 @@
+name: gitleaks
+on: [push, pull_request]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml

--- a/.macos
+++ b/.macos
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# Customize these values for your machine
-COMPUTER_NAME="MacBook-Cesar"
-TIMEZONE="America/El_Salvador"
+# Customize via env vars or defaults
+COMPUTER_NAME="${COMPUTER_NAME:-MacBook-Cesar}"
+TIMEZONE="${TIMEZONE:-America/El_Salvador}"
 
 # Close any open System Preferences panes, to prevent them from overriding
 # settings we’re about to change

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/koalaman/shellcheck
+    rev: v0.9.0
+    hooks:
+      - id: shellcheck
+        files: \.(sh|zsh)$
+  - repo: https://github.com/mvdan/sh
+    rev: v3.7.0
+    hooks:
+      - id: shfmt
+        args: ['-i', '2', '-ci', '-sr']
+  - repo: local
+    hooks:
+      - id: zsh-syntax
+        name: "zsh -n"
+        entry: zsh -n
+        language: system
+        files: \.zsh$
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks
+        args: ["--config=.gitleaks.toml"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Some useful aliases are already provided, including shortcuts for `npm run dev`,
 
 ### Runtimes with mise
 
+After cloning this repo, trust the runtime configuration:
+
+```bash
+mise trust
+```
+
 The `.mise.toml` file defines the versions of Node, PNPM and Python used:
 
 ```toml
@@ -94,7 +100,7 @@ mise use -g node@20 pnpm@9 python@3.12
 
 Use `mise install` whenever you update the versions in `.mise.toml`.
 ### Tasks (Just)
-Install [just](https://github.com/casey/just) and run common tasks:
+Install [just](https://github.com/casey/just) and run common tasks (`just --list` shows them):
 
 ```bash
 just setup      # install dependencies
@@ -127,6 +133,12 @@ sudo apt-get install shellcheck shfmt zsh
 git ls-files '*.sh' | xargs --no-run-if-empty shellcheck
 git ls-files '*.sh' | xargs --no-run-if-empty shfmt -d -i 2 -ci -sr
 git ls-files '*.zsh' | xargs --no-run-if-empty zsh -n
+```
+
+You can also install local hooks with [pre-commit](https://pre-commit.com):
+
+```bash
+pre-commit install
 ```
 
 ## Thanks To...

--- a/fresh.sh
+++ b/fresh.sh
@@ -39,9 +39,12 @@ fi
 # Evaluate Homebrew environment
 if [ -x /opt/homebrew/bin/brew ]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
+
 elif [ -x /usr/local/bin/brew ]; then
   eval "$(/usr/local/bin/brew shellenv)"
 fi
+
+brew analytics off
 
 brew bundle --file "$BREWFILE"
 

--- a/ssh.sh
+++ b/ssh.sh
@@ -20,3 +20,7 @@ else
   printf 'Public key:\n'
   cat "$HOME/.ssh/id_ed25519.pub"
 fi
+
+if command -v gh > /dev/null 2>&1; then
+  gh ssh-key add "$HOME/.ssh/id_ed25519.pub" -t "$(hostname)" || true
+fi


### PR DESCRIPTION
## Summary
- add pre-commit config for shell, zsh and gitleaks checks
- add GitHub Actions workflows for gitleaks and Brewfile check
- allow overriding computer name and timezone via env vars
- turn off Homebrew analytics during install
- add devcontainer configuration and EditorConfig
- upload SSH key with `gh` if available
- document `mise trust`, just tasks and pre-commit hooks

## Testing
- `pre-commit run --files .macos README.md fresh.sh ssh.sh .pre-commit-config.yaml .github/workflows/gitleaks.yml .github/workflows/brew-check.yml .devcontainer/devcontainer.json .editorconfig` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_6884e84f74e4832eb8b13b5a80e73d36