### PR TITLE
Fix Brewfile tap and clarify instructions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 #######################
 # Taps
 #######################
-tap "homebrew/bundle"
 tap "homebrew/cask"
 tap "homebrew/cask-fonts"
 

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1,6 +1,5 @@
 {
   "taps": [
-    "homebrew/bundle",
     "homebrew/cask",
     "homebrew/cask-fonts"
   ],

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ After backing up your old Mac you may now follow these install instructions to s
     git clone --recursive git@github.com:cesaramirez/dotfiles.git ~/.dotfiles
     ```
 
+    **Important**: keep the file named `Brewfile` exactly as provided (case
+    sensitive). Renaming it will make `brew bundle` fail with `No Brewfile
+    found`.
+
 4. Run the installation:
 
     ```zsh


### PR DESCRIPTION
## Summary
- remove deprecated `homebrew/bundle` tap
- mention case-sensitive `Brewfile` requirement in README

## Testing
- `pre-commit` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_6884f07ce334832eb86bc844e8ca42fe