### PR TITLE
Fix brew taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,6 @@
 #######################
 # Taps
 #######################
-tap "homebrew/cask"
-tap "homebrew/cask-fonts"
 
 #######################
 # Core CLI & DX

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1,8 +1,5 @@
 {
-  "taps": [
-    "homebrew/cask",
-    "homebrew/cask-fonts"
-  ],
+  "taps": [],
   "brews": [
     "azure-cli",
     "bat",


### PR DESCRIPTION
## Summary
- remove deprecated `homebrew/cask` taps from Brewfile

## Testing
- `shellcheck` on `*.sh`
- `shfmt -d -i 2 -ci -sr` on `*.sh`
- `zsh -n` on `*.zsh`

------
https://chatgpt.com/codex/tasks/task_e_6885647368fc832e9d10b9f49f537d26