### PR TITLE
Improve brew bundle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,20 @@ After backing up your old Mac you may now follow these install instructions to s
     sensitive). Renaming it will make `brew bundle` fail with `No Brewfile
     found`.
 
-4. Run the installation:
+4. Sign in to the Mac App Store (required for installing apps listed with `mas`)
+
+5. Run the installation:
 
     ```zsh
     cd ~/.dotfiles && ./fresh.sh
     ```
 
-5. Start `Herd.app` and run its install process
-6. Review the `.macos` script and run it to apply system defaults
-7. (Optional) If you use **Mackup** and it’s already synced with your cloud storage, restore preferences:
+6. Start `Herd.app` and run its install process
+7. Review the `.macos` script and run it to apply system defaults
+8. (Optional) If you use **Mackup** and it’s already synced with your cloud storage, restore preferences:
 
         mackup restore
-8. Restart your computer to finalize the process
+9. Restart your computer to finalize the process
 
 Your Mac is now ready to use!
 

--- a/fresh.sh
+++ b/fresh.sh
@@ -46,6 +46,15 @@ fi
 
 brew analytics off
 
+# Skip Mac App Store apps if not signed in
+if grep -q '^mas ' "$BREWFILE"; then
+  command -v mas >/dev/null 2>&1 || brew install mas
+  if ! mas account >/dev/null 2>&1; then
+    echo "Skipping Mac App Store apps: not signed in"
+    export HOMEBREW_BUNDLE_MAS_SKIP=1
+  fi
+fi
+
 brew bundle --file "$BREWFILE"
 
 # Install Oh My Zsh locally if absent


### PR DESCRIPTION
## Summary
- skip Mac App Store installs when not signed in
- note App Store sign-in in setup instructions

## Testing
- `shellcheck fresh.sh install.sh ssh.sh`
- `shfmt -d -i 2 -ci -sr $(git ls-files '*.sh')`
- `zsh -n aliases.zsh path.zsh`

Codex couldn't run `brew bundle` checks because Homebrew wasn't installed in the environment.

------
https://chatgpt.com/codex/tasks/task_e_6885654e0b14832e951f09ab06f2978a